### PR TITLE
Restore ticket_sidebar app icon

### DIFF
--- a/templates/layout.hdbs
+++ b/templates/layout.hdbs
@@ -1,5 +1,5 @@
 <header>
-  {{!-- <span class="logo"/> --}}
+  <span class="logo"/>
   <h3>{{setting "name"}}</h3>
 </header>
 <section data-main/>


### PR DESCRIPTION
:v:

### Description
Restore ticket_sidebar location icon for consistency with other apps. This was removed for reasons unknown in [this commit](https://github.com/zendesklabs/ticket_to_helpcenter/commit/75e00ececb8b1b224d4962e956d0f0b2b774fae8#diff-29c2e742b399fbf325976820caabe8d0).

Before:
<img width="358" alt="Before" src="https://cloud.githubusercontent.com/assets/754567/26382151/9cdd8a64-406d-11e7-8fd8-ebd8c1a125d5.png">

After:
<img width="362" alt="After" src="https://cloud.githubusercontent.com/assets/754567/26382155/a21188c8-406d-11e7-865b-f1630fc33aa8.png">
